### PR TITLE
Perform permissions check on journal icons

### DIFF
--- a/poi-teleport.js
+++ b/poi-teleport.js
@@ -177,23 +177,25 @@ class PointOfInterestTeleporter {
 	 * @memberof PointOfInterestTeleporter
 	 */
 	getOptions() {
-		return [
-			{
-				icon: `<i class="fas fa-bullseye fa-fw"></i>`,
-				title: "poitp.activate",
-				trigger: "activateScene"
-			},
-			{
+		let options = [];
+		if(this.scene.hasPerm(game.user,"3")) {
+			options = [
+				{
+					icon: `<i class="fas fa-bullseye fa-fw"></i>`,
+					title: "poitp.activate",
+					trigger: "activateScene"
+				},
+				{
+					icon: `<i class="fas fa-scroll fa-fw"></i>`,
+					title: "poitp.toggleNav",
+					trigger: "toggleNav"
+				}];
+		}
+		return [{
 				icon: `<i class="fas fa-eye fa-fw"></i>`,
 				title: "poitp.view",
 				trigger: "viewScene"
-			},
-			{
-				icon: `<i class="fas fa-scroll fa-fw"></i>`,
-				title: "poitp.toggleNav",
-				trigger: "toggleNav"
-			}
-		]
+			}].concat(options);
 	}
 	
 	/**


### PR DESCRIPTION
Designed so players won't see the activate/navigation icons without being able to actually use them