### PR TITLE
Updated to use v10 combined Document data structure

### DIFF
--- a/poi-teleport.js
+++ b/poi-teleport.js
@@ -111,7 +111,7 @@ class PointOfInterestTeleporter {
 	 * @memberof PointOfInterestTeleporter
 	 */
 	static checkNote(note) {
-		const scene = game.scenes.find(s => s.data?.journal == note?.entry?.id);
+		const scene = game.scenes.find(s => s?.journal?.id == note?.entry?.id)
 		if (scene) new PointOfInterestTeleporter(note, scene); 
 	}
 


### PR DESCRIPTION
Changing this line made the module work on my v10. Scene#data object is no longer used. Since V10 the Document class and its contained DataModel are merged into a combined data structure.