### PR TITLE
[Resolve #15] - Add Support for Journal Pages introduced in Foundry V10

### DIFF
--- a/poi-teleport.js
+++ b/poi-teleport.js
@@ -146,7 +146,13 @@ class PointOfInterestTeleporter {
 	 * @memberof PointOfInterestTeleporter
 	 */
 	static async checkNote(note) {
-		const scene = game.scenes.find(s => s.journal?.id == note?.entry?.id);
+		let scene;
+
+		if(note?.document?.pageId != null){
+			scene = game.scenes.find(s => (s.journalEntryPage != null && s.journalEntryPage == note?.document?.pageId));
+		}else{
+			scene = game.scenes.find(s => (s.journalEntryPage == null && s.journal?.id == note?.entry?.id));
+		}
 
 		if (!scene) return;
 		if (!await this.waitFor(note, "mouseInteractionManager", 60)) return;


### PR DESCRIPTION
- Allow user to set a Journal Page as a Scene Note and use it as a POI Teleporter
  - Previous behavior caused Pages used as POI Teleporters to only link to scenes which used the "Master" Journal as Scene Notes, or would link to a scene that used a different Page in the same Journal.
  - Example: Journal 1 has 2 pages, Page A and Page B. The user creates 2 scenes, Scene Y, and Scene Z. Scene Y uses Page A as it's notes, and Scene Z uses Page B. Under the previous behavior, when both pages are placed as Pins on the canvas, Page A's pin would successfully teleport to Scene Y, however, Page B's pin would also teleport to Scene Y (Note: Sometimes this behavior would be swapped, with A and B leading to Z). Under the new behavior, Page A's pin will teleport to Scene Y, and Page B's pin will teleport to Scene Z.
- Additional Pages inside of a Journal will now no longer also act as POI Teleporters, unless they are also used as notes by a scene